### PR TITLE
Convert SqlExpr to a final encoding

### DIFF
--- a/src/Database/Esqueleto/Experimental/From.hs
+++ b/src/Database/Esqueleto/Experimental/From.hs
@@ -52,7 +52,7 @@ instance PersistEntity a => From (Table a) where
     runFrom e@Table = do
         let ed = entityDef $ getVal e
         ident <- newIdentFor (entityDB ed)
-        let entity = EEntity ident
+        let entity = unsafeSqlEntity ident
         pure $ (entity, FromStart ident ed)
           where
             getVal ::  Table ent -> Proxy ent

--- a/src/Database/Esqueleto/Experimental/ToAlias.hs
+++ b/src/Database/Esqueleto/Experimental/ToAlias.hs
@@ -23,7 +23,7 @@ instance ToAlias (SqlExpr (Value a)) where
                 ident <- newIdentFor (DBName "v")
                 pure $ ERaw noMeta{sqlExprMetaAlias = Just ident} $ \_ info ->
                     let (b, v) = f Never info
-                    in (b <> " AS " <> useIdent info ident, [])
+                    in (b <> " AS " <> useIdent info ident, v)
 
 
 instance ToAlias (SqlExpr (Entity a)) where

--- a/src/Database/Esqueleto/Experimental/ToAliasReference.hs
+++ b/src/Database/Esqueleto/Experimental/ToAliasReference.hs
@@ -19,22 +19,22 @@ class ToAliasReference a where
 instance ToAliasReference (SqlExpr (Value a)) where
     toAliasReference aliasSource (ERaw m _)
       | Just alias <- sqlExprMetaAlias m = pure $ ERaw m $ \_ info ->
-            (useIdent info aliasSource <> "." <> useIdent info alias, [])
+          (useIdent info aliasSource <> "." <> useIdent info alias, [])
     toAliasReference _ e = pure e
 
 instance ToAliasReference (SqlExpr (Entity a)) where
     toAliasReference aliasSource (ERaw m _)
       | Just _ <- sqlExprMetaAlias m, False <- sqlExprMetaIsReference m =
           pure $ ERaw m{sqlExprMetaIsReference = True} $ \_ info ->
-              (useIdent info aliasSource, [])
+            (useIdent info aliasSource, [])
     toAliasReference _ e = pure e
 
 instance ToAliasReference (SqlExpr (Maybe (Entity a))) where
     -- FIXME: Code duplication because the compiler doesnt like half final encoding
-    toAliasReference aliasSource (ERaw m f)
+    toAliasReference aliasSource (ERaw m _)
       | Just _ <- sqlExprMetaAlias m, False <- sqlExprMetaIsReference m =
           pure $ ERaw m{sqlExprMetaIsReference = True} $ \_ info ->
-              (useIdent info aliasSource, [])
+            (useIdent info aliasSource, [])
     toAliasReference s e = pure e
 
 

--- a/src/Database/Esqueleto/Experimental/ToAliasReference.hs
+++ b/src/Database/Esqueleto/Experimental/ToAliasReference.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}
 
 module Database.Esqueleto.Experimental.ToAliasReference
@@ -17,9 +18,9 @@ class ToAliasReference a where
     toAliasReference :: Ident -> a -> SqlQuery a
 
 instance ToAliasReference (SqlExpr (Value a)) where
-    toAliasReference aliasSource (EAliasedValue aliasIdent _) = pure $ EValueReference aliasSource (\_ -> aliasIdent)
-    toAliasReference _           v@(ERaw _ _)                 = toAlias v
-    toAliasReference s             (EValueReference _ b)      = pure $ EValueReference s b
+    toAliasReference aliasSource (ERaw m _)
+      | Just alias <- sqlExprMetaAlias m = pure $ ERaw noMeta $ \p info ->
+            (useIdent info aliasSource <> "." <> useIdent info alias, [])
 
 instance ToAliasReference (SqlExpr (Entity a)) where
     toAliasReference aliasSource (EAliasedEntity ident _) = pure $ EAliasedEntityReference aliasSource ident

--- a/src/Database/Esqueleto/Experimental/ToAliasReference.hs
+++ b/src/Database/Esqueleto/Experimental/ToAliasReference.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Database.Esqueleto.Experimental.ToAliasReference
     where
 
-import Database.Esqueleto.Experimental.ToAlias
-import Database.Esqueleto.Internal.Internal hiding (From, from, on)
-import Database.Esqueleto.Internal.PersistentImport
+import           Database.Esqueleto.Experimental.ToAlias
+import           Database.Esqueleto.Internal.Internal         hiding (From,
+                                                               from, on)
+import           Database.Esqueleto.Internal.PersistentImport
 
 {-# DEPRECATED ToAliasReferenceT "This type alias doesn't do anything. Please delete it. Will be removed in the next release." #-}
 type ToAliasReferenceT a = a
@@ -18,7 +19,6 @@ class ToAliasReference a where
 instance ToAliasReference (SqlExpr (Value a)) where
     toAliasReference aliasSource (EAliasedValue aliasIdent _) = pure $ EValueReference aliasSource (\_ -> aliasIdent)
     toAliasReference _           v@(ERaw _ _)                 = toAlias v
-    toAliasReference _           v@(ECompositeKey _)          = toAlias v
     toAliasReference s             (EValueReference _ b)      = pure $ EValueReference s b
 
 instance ToAliasReference (SqlExpr (Entity a)) where

--- a/src/Database/Esqueleto/Experimental/ToMaybe.hs
+++ b/src/Database/Esqueleto/Experimental/ToMaybe.hs
@@ -21,7 +21,7 @@ instance ToMaybe (SqlExpr (Maybe a)) where
 
 instance ToMaybe (SqlExpr (Entity a)) where
     type ToMaybeT (SqlExpr (Entity a)) = SqlExpr (Maybe (Entity a))
-    toMaybe = EMaybe
+    toMaybe (ERaw f m) = (ERaw f m)
 
 instance ToMaybe (SqlExpr (Value a)) where
     type ToMaybeT (SqlExpr (Value a)) = SqlExpr (Value (Maybe (Nullable a)))

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE DeriveDataTypeable     #-}
+{-# LANGUAGE EmptyDataDecls         #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE InstanceSigs           #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE Rank2Types             #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE UndecidableInstances   #-}
 
 
 -- | This is an internal module, anything exported by this module
@@ -37,7 +37,6 @@ module Database.Esqueleto.Internal.Sql
       -- * The guts
     , unsafeSqlCase
     , unsafeSqlBinOp
-    , unsafeSqlBinOpComposite
     , unsafeSqlValue
     , unsafeSqlCastAs
     , unsafeSqlFunction
@@ -75,4 +74,4 @@ module Database.Esqueleto.Internal.Sql
     , associateJoin
     ) where
 
-import Database.Esqueleto.Internal.Internal
+import           Database.Esqueleto.Internal.Internal

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE CPP                    #-}
-{-# LANGUAGE ConstraintKinds        #-}
-{-# LANGUAGE DeriveDataTypeable     #-}
-{-# LANGUAGE EmptyDataDecls         #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE InstanceSigs           #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE Rank2Types             #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 
 -- | This is an internal module, anything exported by this module
@@ -38,6 +38,7 @@ module Database.Esqueleto.Internal.Sql
     , unsafeSqlCase
     , unsafeSqlBinOp
     , unsafeSqlValue
+    , unsafeSqlEntity
     , unsafeSqlCastAs
     , unsafeSqlFunction
     , unsafeSqlExtractSubField
@@ -74,4 +75,4 @@ module Database.Esqueleto.Internal.Sql
     , associateJoin
     ) where
 
-import           Database.Esqueleto.Internal.Internal
+import Database.Esqueleto.Internal.Internal

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -182,7 +182,7 @@ upsert
     )
     => record
     -- ^ new record to insert
-    -> [SqlExpr (Update record)]
+    -> [SqlExpr (Entity record) -> SqlExpr Update]
     -- ^ updates to perform if the record already exists
     -> R.ReaderT SqlBackend m (Entity record)
     -- ^ the record in the database after the operation
@@ -200,7 +200,7 @@ upsertBy
     -- ^ uniqueness constraint to find by
     -> record
     -- ^ new record to insert
-    -> [SqlExpr (Update record)]
+    -> [SqlExpr (Entity record) -> SqlExpr Update]
     -- ^ updates to perform if the record already exists
     -> R.ReaderT SqlBackend m (Entity record)
     -- ^ the record in the database after the operation
@@ -276,7 +276,7 @@ insertSelectWithConflict
     -- a unique "MyUnique 0", "MyUnique undefined" would work as well.
     -> SqlQuery (SqlExpr (Insertion val))
     -- ^ Insert query.
-    -> (SqlExpr (Entity val) -> SqlExpr (Entity val) -> [SqlExpr (Update val)])
+    -> (SqlExpr (Entity val) -> SqlExpr (Entity val) -> [SqlExpr (Entity val) -> SqlExpr Update])
     -- ^ A list of updates to be applied in case of the constraint being
     -- violated. The expression takes the current and excluded value to produce
     -- the updates.
@@ -292,7 +292,7 @@ insertSelectWithConflictCount
      . (FinalResult a, KnowResult a ~ Unique val, MonadIO m, PersistEntity val)
     => a
     -> SqlQuery (SqlExpr (Insertion val))
-    -> (SqlExpr (Entity val) -> SqlExpr (Entity val) -> [SqlExpr (Update val)])
+    -> (SqlExpr (Entity val) -> SqlExpr (Entity val) -> [SqlExpr (Entity val) -> SqlExpr Update])
     -> SqlWriteT m Int64
 insertSelectWithConflictCount unique query conflictQuery = do
     conn <- R.ask

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module contain PostgreSQL-specific functions.
@@ -31,23 +31,22 @@ module Database.Esqueleto.PostgreSQL
     ) where
 
 #if __GLASGOW_HASKELL__ < 804
-import           Data.Semigroup
+import Data.Semigroup
 #endif
-import           Control.Arrow                                (first, (***))
-import           Control.Exception                            (throw)
-import           Control.Monad                                (void)
-import           Control.Monad.IO.Class                       (MonadIO (..))
-import qualified Control.Monad.Trans.Reader                   as R
-import           Data.Int                                     (Int64)
-import           Data.List.NonEmpty                           (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty                           as NonEmpty
-import           Data.Proxy                                   (Proxy (..))
-import qualified Data.Text.Internal.Builder                   as TLB
-import           Data.Time.Clock                              (UTCTime)
-import           Database.Esqueleto.Internal.Internal         hiding (random_)
-import           Database.Esqueleto.Internal.PersistentImport hiding (upsert,
-                                                               upsertBy)
-import           Database.Persist.Class                       (OnlyOneUniqueKey)
+import Control.Arrow (first, (***))
+import Control.Exception (throw)
+import Control.Monad (void)
+import Control.Monad.IO.Class (MonadIO(..))
+import qualified Control.Monad.Trans.Reader as R
+import Data.Int (Int64)
+import Data.List.NonEmpty (NonEmpty((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Proxy (Proxy(..))
+import qualified Data.Text.Internal.Builder as TLB
+import Data.Time.Clock (UTCTime)
+import Database.Esqueleto.Internal.Internal hiding (random_)
+import Database.Esqueleto.Internal.PersistentImport hiding (upsert, upsertBy)
+import Database.Persist.Class (OnlyOneUniqueKey)
 
 -- | (@random()@) Split out into database specific modules
 -- because MySQL uses `rand()`.
@@ -306,9 +305,9 @@ insertSelectWithConflictCount unique query conflictQuery = do
     proxy = Proxy
     updates = conflictQuery entCurrent entExcluded
     combine (tlb1,vals1) (tlb2,vals2) = (builderToText (tlb1 `mappend` tlb2), vals1 ++ vals2)
-    entExcluded = EEntity $ I "excluded"
+    entExcluded = unsafeSqlEntity (I "excluded")
     tableName = unDBName . entityDB . entityDef
-    entCurrent = EEntity $ I (tableName proxy)
+    entCurrent = unsafeSqlEntity (I (tableName proxy))
     uniqueDef = toUniqueDef unique
     constraint = TLB.fromText . unDBName . uniqueDBName $ uniqueDef
     renderedUpdates :: (BackendCompatible SqlBackend backend) => backend -> (TLB.Builder, [PersistValue])

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -298,7 +298,7 @@ insertSelectWithConflictCount unique query conflictQuery = do
     conn <- R.ask
     uncurry rawExecuteCount $
         combine
-            (toRawSql INSERT_INTO (conn, initialIdentState) (fmap EInsertFinal query))
+            (toRawSql INSERT_INTO (conn, initialIdentState) query)
             (conflict conn)
   where
     proxy :: Proxy val

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PartialTypeSignatures      #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
@@ -62,37 +62,41 @@ module Common.Test
     , Key(..)
     ) where
 
-import Control.Monad (forM_, replicateM, replicateM_, void)
-import Control.Monad.Catch (MonadCatch)
-import Control.Monad.Reader (ask)
-import Data.Either
-import Data.Time
+import           Control.Monad                          (forM_, replicateM,
+                                                         replicateM_, void)
+import           Control.Monad.Catch                    (MonadCatch)
+import           Control.Monad.Reader                   (ask)
+import           Data.Either
+import           Data.Time
 #if __GLASGOW_HASKELL__ >= 806
-import Control.Monad.Fail (MonadFail)
+import           Control.Monad.Fail                     (MonadFail)
 #endif
-import Control.Monad.IO.Class (MonadIO(liftIO))
-import Control.Monad.Logger (MonadLogger(..), NoLoggingT, runNoLoggingT)
-import Control.Monad.Trans.Reader (ReaderT)
-import qualified Data.Attoparsec.Text as AP
-import Data.Char (toLower, toUpper)
-import Data.Monoid ((<>))
-import Database.Esqueleto
-import Database.Esqueleto.Experimental hiding (from, on)
-import qualified Database.Esqueleto.Experimental as Experimental
-import Database.Persist.TH
-import Test.Hspec
-import UnliftIO
+import           Control.Monad.IO.Class                 (MonadIO (liftIO))
+import           Control.Monad.Logger                   (MonadLogger (..),
+                                                         NoLoggingT,
+                                                         runNoLoggingT)
+import           Control.Monad.Trans.Reader             (ReaderT)
+import qualified Data.Attoparsec.Text                   as AP
+import           Data.Char                              (toLower, toUpper)
+import           Data.Monoid                            ((<>))
+import           Database.Esqueleto
+import           Database.Esqueleto.Experimental        hiding (from, on)
+import qualified Database.Esqueleto.Experimental        as Experimental
+import           Database.Persist.TH
+import           Test.Hspec
+import           UnliftIO
 
-import Data.Conduit (ConduitT, runConduit, (.|))
-import qualified Data.Conduit.List as CL
-import qualified Data.List as L
-import qualified Data.Set as S
-import qualified Data.Text as Text
-import qualified Data.Text.Internal.Lazy as TL
-import qualified Data.Text.Lazy.Builder as TLB
+import           Data.Conduit                           (ConduitT, runConduit,
+                                                         (.|))
+import qualified Data.Conduit.List                      as CL
+import qualified Data.List                              as L
+import qualified Data.Set                               as S
+import qualified Data.Text                              as Text
+import qualified Data.Text.Internal.Lazy                as TL
+import qualified Data.Text.Lazy.Builder                 as TLB
 import qualified Database.Esqueleto.Internal.ExprParser as P
-import qualified Database.Esqueleto.Internal.Sql as EI
-import qualified UnliftIO.Resource as R
+import qualified Database.Esqueleto.Internal.Sql        as EI
+import qualified UnliftIO.Resource                      as R
 
 -- Test schema
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
@@ -1078,17 +1082,6 @@ testSelectWhere run = describe "select where_" $ do
                         ( val $ PointKey 1 2
                         , val $ PointKey 5 6 )
                 liftIO $ ret `shouldBe` [()]
-            it "works when using ECompositeKey constructor" $ run $ do
-                insert_ $ Point 1 2 ""
-                ret <-
-                  select $
-                  from $ \p -> do
-                  where_ $
-                    p ^. PointId
-                      `between`
-                        ( EI.ECompositeKey $ const ["3", "4"]
-                        , EI.ECompositeKey $ const ["5", "6"] )
-                liftIO $ ret `shouldBe` []
 
     it "works with avg_" $ run $ do
         _ <- insert' p1

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -894,7 +894,6 @@ testSelectSubQuery run = describe "select subquery" $ do
                       `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
                   pure (lords, deeds)
 
-        liftIO . print =<< renderQuerySelect q
         ret <- select q
         liftIO $ ret `shouldMatchList` ((l3e, Nothing) : l1WithDeeds)
 

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE EmptyDataDecls             #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE PartialTypeSignatures      #-}
-{-# LANGUAGE QuasiQuotes                #-}
-{-# LANGUAGE Rank2Types                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeSynonymInstances       #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
@@ -62,41 +62,37 @@ module Common.Test
     , Key(..)
     ) where
 
-import           Control.Monad                          (forM_, replicateM,
-                                                         replicateM_, void)
-import           Control.Monad.Catch                    (MonadCatch)
-import           Control.Monad.Reader                   (ask)
-import           Data.Either
-import           Data.Time
+import Control.Monad (forM_, replicateM, replicateM_, void)
+import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Reader (ask)
+import Data.Either
+import Data.Time
 #if __GLASGOW_HASKELL__ >= 806
-import           Control.Monad.Fail                     (MonadFail)
+import Control.Monad.Fail (MonadFail)
 #endif
-import           Control.Monad.IO.Class                 (MonadIO (liftIO))
-import           Control.Monad.Logger                   (MonadLogger (..),
-                                                         NoLoggingT,
-                                                         runNoLoggingT)
-import           Control.Monad.Trans.Reader             (ReaderT)
-import qualified Data.Attoparsec.Text                   as AP
-import           Data.Char                              (toLower, toUpper)
-import           Data.Monoid                            ((<>))
-import           Database.Esqueleto
-import           Database.Esqueleto.Experimental        hiding (from, on)
-import qualified Database.Esqueleto.Experimental        as Experimental
-import           Database.Persist.TH
-import           Test.Hspec
-import           UnliftIO
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Logger (MonadLogger(..), NoLoggingT, runNoLoggingT)
+import Control.Monad.Trans.Reader (ReaderT)
+import qualified Data.Attoparsec.Text as AP
+import Data.Char (toLower, toUpper)
+import Data.Monoid ((<>))
+import Database.Esqueleto
+import Database.Esqueleto.Experimental hiding (from, on)
+import qualified Database.Esqueleto.Experimental as Experimental
+import Database.Persist.TH
+import Test.Hspec
+import UnliftIO
 
-import           Data.Conduit                           (ConduitT, runConduit,
-                                                         (.|))
-import qualified Data.Conduit.List                      as CL
-import qualified Data.List                              as L
-import qualified Data.Set                               as S
-import qualified Data.Text                              as Text
-import qualified Data.Text.Internal.Lazy                as TL
-import qualified Data.Text.Lazy.Builder                 as TLB
+import Data.Conduit (ConduitT, runConduit, (.|))
+import qualified Data.Conduit.List as CL
+import qualified Data.List as L
+import qualified Data.Set as S
+import qualified Data.Text as Text
+import qualified Data.Text.Internal.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TLB
 import qualified Database.Esqueleto.Internal.ExprParser as P
-import qualified Database.Esqueleto.Internal.Sql        as EI
-import qualified UnliftIO.Resource                      as R
+import qualified Database.Esqueleto.Internal.Sql as EI
+import qualified UnliftIO.Resource as R
 
 -- Test schema
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
@@ -390,7 +386,6 @@ testSubSelect run = do
 
     describe "subSelectList" $ do
         it "is safe on empty databases as well as good databases" $ run $ do
-            liftIO $ putStrLn "hello"
             let query =
                     from $ \n -> do
                     where_ $ n ^. NumbersInt `in_` do
@@ -399,10 +394,7 @@ testSubSelect run = do
                             where_ $ n' ^. NumbersInt >=. val 3
                             pure (n' ^. NumbersInt)
                     pure n
-            empty <- do
-                liftIO . print =<<  renderQuerySelect query
-                select query
-            liftIO $ putStrLn "goodbye"
+            empty <- select query
 
             full <- do
                 setup
@@ -895,12 +887,15 @@ testSelectSubQuery run = describe "select subquery" $ do
         l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1e)) (map show [1..3 :: Int])
         let l1WithDeeds = do d <- l1Deeds
                              pure (l1e, Just d)
-        ret <- select $ Experimental.from $ do
-          (lords :& deeds) <-
-              Experimental.from $ Table @Lord
-              `LeftOuterJoin` Table @Deed
-              `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
-          pure (lords, deeds)
+        let q = Experimental.from $ do
+                  (lords :& deeds) <-
+                      Experimental.from $ Table @Lord
+                      `LeftOuterJoin` Table @Deed
+                      `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
+                  pure (lords, deeds)
+
+        liftIO . print =<< renderQuerySelect q
+        ret <- select q
         liftIO $ ret `shouldMatchList` ((l3e, Nothing) : l1WithDeeds)
 
     it "lets you order by alias" $ run $ do
@@ -1847,9 +1842,10 @@ testRenderSql run = do
       (c, expr) <- run $ do
         conn <- ask
         let Right c = P.mkEscapeChar conn
+        let user = EI.unsafeSqlEntity (EI.I "user")
+            blogPost = EI.unsafeSqlEntity (EI.I "blog_post")
         pure $ (,) c $ EI.renderExpr conn $
-          EI.EEntity (EI.I "user") ^. PersonId
-          ==. EI.EEntity (EI.I "blog_post") ^. BlogPostAuthorId
+          user ^. PersonId ==. blogPost ^. BlogPostAuthorId
       expr
         `shouldBe`
           Text.intercalate (Text.singleton c) ["", "user", ".", "id", ""]
@@ -1860,23 +1856,6 @@ testRenderSql run = do
     it "renders ? for a val" $ do
       expr <- run $ ask >>= \c -> pure $ EI.renderExpr c (val (PersonKey 0) ==. val (PersonKey 1))
       expr `shouldBe` "? = ?"
-
-  describe "EEntity Ident behavior" $ do
-      let render :: SqlExpr (Entity val) -> Text.Text
-          render (EI.EEntity (EI.I ident)) = ident
-          render _ = error "guess we gotta handle this in the test suite now"
-      it "renders sensibly" $ run $ do
-          _ <- insert $ Foo 2
-          _ <- insert $ Foo 3
-          _ <- insert $ Person "hello" Nothing Nothing 3
-          results <- select $
-              from $ \(a `LeftOuterJoin` b) -> do
-              on $ a ^. FooName ==. b ^. PersonFavNum
-              pure (val (render a), val (render b))
-          liftIO $
-              head results
-              `shouldBe`
-              (Value "Foo", Value "Person")
 
   describe "ExprParser" $ do
     let parse parser = AP.parseOnly (parser '#')

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -389,7 +389,8 @@ testSubSelect run = do
                     v `shouldBe` [Value 1]
 
     describe "subSelectList" $ do
-        it "is safe on empty databases as well as good databases" $ do
+        it "is safe on empty databases as well as good databases" $ run $ do
+            liftIO $ putStrLn "hello"
             let query =
                     from $ \n -> do
                     where_ $ n ^. NumbersInt `in_` do
@@ -398,16 +399,18 @@ testSubSelect run = do
                             where_ $ n' ^. NumbersInt >=. val 3
                             pure (n' ^. NumbersInt)
                     pure n
-
-            empty <- run $ do
+            empty <- do
+                liftIO . print =<<  renderQuerySelect query
                 select query
+            liftIO $ putStrLn "goodbye"
 
-            full <- run $ do
+            full <- do
                 setup
                 select query
 
-            empty `shouldBe` []
-            full `shouldSatisfy` (not . null)
+            liftIO $ do
+                empty `shouldBe` []
+                full `shouldSatisfy` (not . null)
 
     describe "subSelectMaybe" $ do
         it "is equivalent to joinV . subSelect" $ do


### PR DESCRIPTION
Remove all `SqlExpr` constructors except for `ERaw`
Change `ERaw` NeedParens semantics. A value will be told if it is in a context which parens should be used.

This change de-priveleges `Value` allowing the creation of new `SqlExpr` types completely independent of Internal.Internal. 

Additionally it unifies the codepaths of Alias/AliasReference creating simpler code.

Another side benefit is that existing clutter has been removed, `SqlExpr` had basically grown into a dumping ground and because it did so much it would pull a lot of code with it. 

Possible future work enabled by this change:
Desolation of Value - Currently I have a branch that removes Value entirely, this may not be ideal since Value is a nice place to hang instances

Improvements to aggregates - Another branch has a new `groupBy` that tags everything as `Aggregate`, this would have previously required a new constructor in SqlExpr but can be implemented with almost no changes

Window functions - Window functions produce values that are only legal in `HAVING` and as values to select. This means that they need a new type, this also can be implemented independent of the core code. 